### PR TITLE
feat: add NestJS backend on EC2 for RDS connection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,144 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is a personal website/blog built as a monorepo using pnpm workspaces. The project consists of:
+- **Frontend**: Next.js 15 application (App Router) with TypeScript, Tailwind CSS, and Framer Motion
+- **Backend**: NestJS application (currently minimal/placeholder)
+
+The site showcases personal introduction, projects, and blog posts stored in MySQL, with images served from CloudFront CDN.
+
+## Common Commands
+
+### Development
+```bash
+# Run both frontend and backend concurrently
+pnpm dev
+
+# Run only frontend (most common for development)
+pnpm dev:frontend
+
+# Run only backend
+pnpm dev:backend
+```
+
+### Building
+```bash
+# Build all packages
+pnpm build
+
+# Build specific workspace
+pnpm build:frontend
+pnpm build:backend
+```
+
+### Linting
+```bash
+# Lint all packages
+pnpm lint
+```
+
+### Post Management
+```bash
+# Import markdown posts from src/data/posts/ to MySQL database
+# Run from apps/frontend directory
+node src/scripts/importPosts.cjs
+```
+
+### Testing (Backend)
+```bash
+# Run from apps/backend directory
+pnpm test           # Unit tests
+pnpm test:watch     # Watch mode
+pnpm test:e2e       # E2E tests
+pnpm test:cov       # Coverage report
+```
+
+## Architecture
+
+### Monorepo Structure
+- `/apps/frontend` - Next.js frontend application
+- `/apps/backend` - NestJS backend (minimal, mostly unused currently)
+- Root `package.json` contains workspace scripts using pnpm filters
+
+### Frontend Architecture
+
+#### App Router Structure
+- **Home page** (`/`): Landing page with introduction
+- **Post list** (`/post`): Blog post listing page
+- **Post detail** (`/post/[displayId]`): Individual post view using display ID (reverse chronological order number)
+
+#### API Routes
+- `GET /api/posts` - Fetches all posts from MySQL, adds `displayId` (reverse chronological numbering)
+- `GET /api/posts/[displayId]` - Fetches single post by display ID
+
+#### Database Integration
+- Uses `mysql2/promise` for direct MySQL connection (no ORM)
+- Connection pool configured via environment variables in `src/lib/db.js`
+- Posts table schema: `id`, `title`, `body` (markdown), `created_at`, `updated_at`
+- Display IDs are computed: `displayId = total_posts - index` (reverse chronological)
+
+#### Post Content Flow
+1. Markdown files placed in `src/data/posts/`
+2. Run `importPosts.cjs` script to parse markdown and insert into MySQL
+3. Script transforms image paths to CloudFront URLs with format: `https://d1faf0kcj4x8qr.cloudfront.net/posts/{UUID}-{number}.png`
+4. Frontend fetches from API routes and renders with `react-markdown` + `remark-gfm`
+
+#### Key Dependencies
+- **Styling**: Tailwind CSS with `tailwindcss-animate`, `class-variance-authority`, `clsx`, `tailwind-merge`
+- **Animation**: Framer Motion
+- **UI Components**: Radix UI (Dialog), Vaul (drawer), custom UI components in `src/components/ui/`
+- **Markdown**: `react-markdown` with `remark-gfm` for GitHub Flavored Markdown
+- **Icons**: `lucide-react`, `react-icons`
+
+#### Path Aliases
+- `@/*` maps to `src/*` (configured in `tsconfig.json`)
+
+#### Environment Variables
+Required in `apps/frontend/.env.local`:
+```
+DB_HOST=<rds-endpoint>
+DB_USER=<username>
+DB_PASSWORD=<password>
+DB_NAME=<database>
+DB_PORT=3306
+API_BASE_URL=<base-url-for-ssr-fetch>
+```
+
+#### Image Handling
+- Next.js Image component configured to allow CloudFront domain: `d1faf0kcj4x8qr.cloudfront.net`
+- Images in markdown posts are served from CloudFront CDN
+- Import script generates UUID-based image filenames
+
+### Backend Architecture
+- Standard NestJS structure with placeholder app module
+- Currently not actively used; frontend connects directly to MySQL
+- Uses Jest for testing with `ts-jest` transformer
+
+## Development Notes
+
+### Routing
+- Post URLs use `displayId` (reverse chronological number) instead of database `id`
+- This ensures newest posts have highest numbers (e.g., post #10 is newer than #9)
+- Computed server-side in API routes: `displayId = totalPosts - arrayIndex`
+
+### Async Route Params
+- Next.js 15 uses Promise-based params: `const { displayId } = await params;`
+- This applies to both page components and API route handlers
+
+### Markdown Rendering
+- Custom ReactMarkdown components defined in `post/[displayId]/page.tsx`
+- Handles code blocks, blockquotes, headings, lists, images with specific styling
+- Images rendered with Next.js Image component for optimization
+
+### TypeScript Configuration
+- Strict mode enabled
+- Target: ES2017
+- Module resolution: bundler (Next.js default)
+
+### Git Workflow
+- Main branch: `main`
+- Current feature branch: `feat/post-nestjs`
+- PR template available at `.github/PULL_REQUEST_TEMPLATE.md`

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -21,10 +21,14 @@
   },
   "dependencies": {
     "@nestjs/common": "^11.0.1",
+    "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.0.1",
     "@nestjs/platform-express": "^11.0.1",
+    "@nestjs/typeorm": "^11.0.0",
+    "mysql2": "^3.15.3",
     "reflect-metadata": "^0.2.2",
-    "rxjs": "^7.8.1"
+    "rxjs": "^7.8.1",
+    "typeorm": "^0.3.27"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -1,9 +1,27 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ConfigModule } from '@nestjs/config';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { PostsModule } from './posts/posts.module';
 
 @Module({
-  imports: [],
+  imports: [
+    ConfigModule.forRoot({
+      isGlobal: true,
+    }),
+    TypeOrmModule.forRoot({
+      type: 'mysql',
+      host: process.env.DB_HOST || 'localhost',
+      port: parseInt(process.env.DB_PORT || '3306', 10),
+      username: process.env.DB_USER || 'root',
+      password: process.env.DB_PASSWORD || '',
+      database: process.env.DB_NAME || 'crohasang_page',
+      entities: [__dirname + '/**/*.entity{.ts,.js}'],
+      synchronize: false,
+    }),
+    PostsModule,
+  ],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -3,6 +3,19 @@ import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
-  await app.listen(process.env.PORT ?? 4000);
+
+  // CORS 설정
+  app.enableCors({
+    origin: [
+      'http://localhost:3000',
+      'https://crohasang.com',
+      'https://www.crohasang.com',
+    ],
+    credentials: true,
+  });
+
+  const port = process.env.PORT || 3001;
+  await app.listen(port);
+  console.log(`🚀 Backend server running on http://localhost:${port}`);
 }
 bootstrap();

--- a/apps/backend/src/posts/post.entity.ts
+++ b/apps/backend/src/posts/post.entity.ts
@@ -1,0 +1,19 @@
+import { Entity, Column, PrimaryGeneratedColumn, CreateDateColumn, UpdateDateColumn } from 'typeorm';
+
+@Entity('posts')
+export class Post {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ type: 'varchar', length: 255 })
+  title: string;
+
+  @Column({ type: 'text' })
+  body: string;
+
+  @CreateDateColumn({ name: 'created_at' })
+  created_at: Date;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updated_at: Date;
+}

--- a/apps/backend/src/posts/posts.controller.ts
+++ b/apps/backend/src/posts/posts.controller.ts
@@ -1,0 +1,17 @@
+import { Controller, Get, Param, ParseIntPipe } from '@nestjs/common';
+import { PostsService } from './posts.service';
+
+@Controller('posts')
+export class PostsController {
+  constructor(private readonly postsService: PostsService) {}
+
+  @Get()
+  findAll() {
+    return this.postsService.findAll();
+  }
+
+  @Get(':displayId')
+  findOne(@Param('displayId', ParseIntPipe) displayId: number) {
+    return this.postsService.findByDisplayId(displayId);
+  }
+}

--- a/apps/backend/src/posts/posts.module.ts
+++ b/apps/backend/src/posts/posts.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { PostsController } from './posts.controller';
+import { PostsService } from './posts.service';
+import { Post } from './post.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Post])],
+  controllers: [PostsController],
+  providers: [PostsService],
+})
+export class PostsModule {}

--- a/apps/backend/src/posts/posts.service.ts
+++ b/apps/backend/src/posts/posts.service.ts
@@ -1,0 +1,40 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Post } from './post.entity';
+
+@Injectable()
+export class PostsService {
+  constructor(
+    @InjectRepository(Post)
+    private postsRepository: Repository<Post>,
+  ) {}
+
+  async findAll() {
+    const posts = await this.postsRepository.find({
+      order: { created_at: 'DESC' },
+    });
+
+    // displayId 추가
+    const postsWithDisplayId = posts.map((post, index) => ({
+      ...post,
+      displayId: posts.length - index,
+    }));
+
+    return postsWithDisplayId;
+  }
+
+  async findByDisplayId(displayId: number) {
+    const posts = await this.postsRepository.find({
+      order: { created_at: 'DESC' },
+    });
+
+    const postIndex = posts.length - displayId;
+
+    if (postIndex < 0 || postIndex >= posts.length) {
+      throw new NotFoundException('Post not found');
+    }
+
+    return posts[postIndex];
+  }
+}

--- a/apps/frontend/src/app/api/posts/[displayId]/route.ts
+++ b/apps/frontend/src/app/api/posts/[displayId]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
-import pool from '@/lib/db';
-import { RowDataPacket } from 'mysql2/promise';
+
+const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:3001';
 
 export async function GET(
   req: NextRequest,
@@ -8,22 +8,21 @@ export async function GET(
 ) {
   try {
     const { displayId } = await params;
-    const connection = await pool.getConnection();
-    const [rows] = await connection.query<RowDataPacket[]>(
-      'SELECT * FROM posts ORDER BY created_at DESC'
-    );
-    connection.release();
-    
-    const displayIdNum = parseInt(displayId);
-    const postIndex = rows.length - displayIdNum;
-    
-    if (postIndex < 0 || postIndex >= rows.length) {
-      return NextResponse.json({ error: 'Post not found' }, { status: 404 });
+    const response = await fetch(`${BACKEND_URL}/posts/${displayId}`, {
+      cache: 'no-store',
+    });
+
+    if (!response.ok) {
+      if (response.status === 404) {
+        return NextResponse.json({ error: 'Post not found' }, { status: 404 });
+      }
+      throw new Error(`Backend responded with status: ${response.status}`);
     }
-    
-    return NextResponse.json(rows[postIndex]);
+
+    const data = await response.json();
+    return NextResponse.json(data);
   } catch (error) {
-    console.error('DB 에러:', error);
+    console.error('Backend 에러:', error);
     const errorMessage = error instanceof Error ? error.message : String(error);
     return NextResponse.json({ error: errorMessage }, { status: 500 });
   }

--- a/apps/frontend/src/app/api/posts/route.ts
+++ b/apps/frontend/src/app/api/posts/route.ts
@@ -1,24 +1,21 @@
 import { NextRequest, NextResponse } from 'next/server';
-import pool from '@/lib/db';
-import { RowDataPacket } from 'mysql2/promise';
+
+const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:3001';
 
 export async function GET(req: NextRequest) {
   try {
-    const connection = await pool.getConnection();
-    const [rows] = await connection.query<RowDataPacket[]>(
-      'SELECT * FROM posts ORDER BY created_at DESC'
-    );
-    connection.release();
-    
-    // displayId 추가
-    const postsWithDisplayId = (rows as any[]).map((post, index) => ({
-      ...post,
-      displayId: rows.length - index
-    }));
-    
-    return NextResponse.json(postsWithDisplayId);
+    const response = await fetch(`${BACKEND_URL}/posts`, {
+      cache: 'no-store',
+    });
+
+    if (!response.ok) {
+      throw new Error(`Backend responded with status: ${response.status}`);
+    }
+
+    const data = await response.json();
+    return NextResponse.json(data);
   } catch (error) {
-    console.error('DB 에러:', error);
+    console.error('Backend 에러:', error);
     const errorMessage = error instanceof Error ? error.message : String(error);
     return NextResponse.json({ error: errorMessage }, { status: 500 });
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,18 +17,30 @@ importers:
       '@nestjs/common':
         specifier: ^11.0.1
         version: 11.1.3(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/config':
+        specifier: ^4.0.2
+        version: 4.0.2(@nestjs/common@11.1.3(reflect-metadata@0.2.2)(rxjs@7.8.2))(rxjs@7.8.2)
       '@nestjs/core':
         specifier: ^11.0.1
         version: 11.1.3(@nestjs/common@11.1.3(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/platform-express':
         specifier: ^11.0.1
         version: 11.1.3(@nestjs/common@11.1.3(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.3)
+      '@nestjs/typeorm':
+        specifier: ^11.0.0
+        version: 11.0.0(@nestjs/common@11.1.3(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typeorm@0.3.27(mysql2@3.15.3)(reflect-metadata@0.2.2)(ts-node@10.9.2(@swc/core@1.12.1)(@types/node@22.15.31)(typescript@5.8.3)))
+      mysql2:
+        specifier: ^3.15.3
+        version: 3.15.3
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
       rxjs:
         specifier: ^7.8.1
         version: 7.8.2
+      typeorm:
+        specifier: ^0.3.27
+        version: 0.3.27(mysql2@3.15.3)(reflect-metadata@0.2.2)(ts-node@10.9.2(@swc/core@1.12.1)(@types/node@22.15.31)(typescript@5.8.3))
     devDependencies:
       '@eslint/eslintrc':
         specifier: ^3.2.0
@@ -971,6 +983,12 @@ packages:
       class-validator:
         optional: true
 
+  '@nestjs/config@4.0.2':
+    resolution: {integrity: sha512-McMW6EXtpc8+CwTUwFdg6h7dYcBUpH5iUILCclAsa+MbCEvC9ZKu4dCHRlJqALuhjLw97pbQu62l4+wRwGeZqA==}
+    peerDependencies:
+      '@nestjs/common': ^10.0.0 || ^11.0.0
+      rxjs: ^7.1.0
+
   '@nestjs/core@11.1.3':
     resolution: {integrity: sha512-5lTni0TCh8x7bXETRD57pQFnKnEg1T6M+VLE7wAmyQRIecKQU+2inRGZD+A4v2DC1I04eA0WffP0GKLxjOKlzw==}
     engines: {node: '>= 20'}
@@ -1012,6 +1030,15 @@ packages:
         optional: true
       '@nestjs/platform-express':
         optional: true
+
+  '@nestjs/typeorm@11.0.0':
+    resolution: {integrity: sha512-SOeUQl70Lb2OfhGkvnh4KXWlsd+zA08RuuQgT7kKbzivngxzSo1Oc7Usu5VxCxACQC9wc2l9esOHILSJeK7rJA==}
+    peerDependencies:
+      '@nestjs/common': ^10.0.0 || ^11.0.0
+      '@nestjs/core': ^10.0.0 || ^11.0.0
+      reflect-metadata: ^0.1.13 || ^0.2.0
+      rxjs: ^7.2.0
+      typeorm: ^0.3.0
 
   '@next/env@15.3.3':
     resolution: {integrity: sha512-OdiMrzCl2Xi0VTjiQQUK0Xh7bJHnOuET2s+3V+Y40WJBAXrJeGA3f+I8MZJ/YQ3mVGi5XGR1L66oFlgqXhQ4Vw==}
@@ -1295,6 +1322,9 @@ packages:
 
   '@sinonjs/fake-timers@10.3.0':
     resolution: {integrity: sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==}
+
+  '@sqltools/formatter@1.2.5':
+    resolution: {integrity: sha512-Uy0+khmZqUrUGm5dmMqVlnvufZRSK0FbYzVgp0UMstm+F5+W2/jnEEQyc9vo1ZR/E5ZI/B1WjjoTqBqwJL6Krw==}
 
   '@swc/cli@0.6.0':
     resolution: {integrity: sha512-Q5FsI3Cw0fGMXhmsg7c08i4EmXCrcl+WnAxb6LYOLHw4JFFC3yzmx9LaXZ7QMbA+JZXbigU2TirI7RAfO0Qlnw==}
@@ -1882,6 +1912,10 @@ packages:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
 
+  app-root-path@3.1.0:
+    resolution: {integrity: sha512-biN3PwB2gUtjaYy/isrU3aNWI5w+fAfvHkSvCKeQGxhmYpwKFUxudR3Yya+KqVRHBmEDYh+/lTozYCFbmzX4nA==}
+    engines: {node: '>= 6.0.0'}
+
   append-field@1.0.0:
     resolution: {integrity: sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==}
 
@@ -2071,6 +2105,9 @@ packages:
 
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+
+  buffer@6.0.3:
+    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
   busboy@1.6.0:
     resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
@@ -2345,6 +2382,9 @@ packages:
     resolution: {integrity: sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==}
     engines: {node: '>=0.11'}
 
+  dayjs@1.11.19:
+    resolution: {integrity: sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==}
+
   debug@3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
     peerDependencies:
@@ -2453,6 +2493,18 @@ packages:
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
+
+  dotenv-expand@12.0.1:
+    resolution: {integrity: sha512-LaKRbou8gt0RNID/9RoI+J2rvXsBRPMV7p+ElHlPhcSARbCPDYcYG2s1TIzAfWv4YSgyY5taidWzzs31lNV3yQ==}
+    engines: {node: '>=12'}
+
+  dotenv@16.4.7:
+    resolution: {integrity: sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==}
+    engines: {node: '>=12'}
+
+  dotenv@16.6.1:
+    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
 
   dotenv@17.2.3:
     resolution: {integrity: sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==}
@@ -4484,6 +4536,11 @@ packages:
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
+  sha.js@2.4.12:
+    resolution: {integrity: sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==}
+    engines: {node: '>= 0.10'}
+    hasBin: true
+
   sharp@0.34.2:
     resolution: {integrity: sha512-lszvBmB9QURERtyKT2bNmsgxXK0ShJrL/fvqlonCo7e6xBF8nT8xU6pW+PMIbLsz0RxQk3rgH9kd8UmvOzlMJg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
@@ -4567,6 +4624,10 @@ packages:
 
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+
+  sql-highlight@6.1.0:
+    resolution: {integrity: sha512-ed7OK4e9ywpE7pgRMkMQmZDPKSVdm0oX5IEtZiKnFucSF0zu6c80GZBe38UqHuVhTWJ9xsKgSMjCG2bml86KvA==}
+    engines: {node: '>=14'}
 
   sqlstring@2.3.3:
     resolution: {integrity: sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==}
@@ -4799,6 +4860,10 @@ packages:
   tmpl@1.0.5:
     resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
 
+  to-buffer@1.2.2:
+    resolution: {integrity: sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==}
+    engines: {node: '>= 0.4'}
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
@@ -4934,6 +4999,62 @@ packages:
 
   typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
+
+  typeorm@0.3.27:
+    resolution: {integrity: sha512-pNV1bn+1n8qEe8tUNsNdD8ejuPcMAg47u2lUGnbsajiNUr3p2Js1XLKQjBMH0yMRMDfdX8T+fIRejFmIwy9x4A==}
+    engines: {node: '>=16.13.0'}
+    hasBin: true
+    peerDependencies:
+      '@google-cloud/spanner': ^5.18.0 || ^6.0.0 || ^7.0.0
+      '@sap/hana-client': ^2.14.22
+      better-sqlite3: ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0
+      ioredis: ^5.0.4
+      mongodb: ^5.8.0 || ^6.0.0
+      mssql: ^9.1.1 || ^10.0.1 || ^11.0.1
+      mysql2: ^2.2.5 || ^3.0.1
+      oracledb: ^6.3.0
+      pg: ^8.5.1
+      pg-native: ^3.0.0
+      pg-query-stream: ^4.0.0
+      redis: ^3.1.1 || ^4.0.0 || ^5.0.14
+      reflect-metadata: ^0.1.14 || ^0.2.0
+      sql.js: ^1.4.0
+      sqlite3: ^5.0.3
+      ts-node: ^10.7.0
+      typeorm-aurora-data-api-driver: ^2.0.0 || ^3.0.0
+    peerDependenciesMeta:
+      '@google-cloud/spanner':
+        optional: true
+      '@sap/hana-client':
+        optional: true
+      better-sqlite3:
+        optional: true
+      ioredis:
+        optional: true
+      mongodb:
+        optional: true
+      mssql:
+        optional: true
+      mysql2:
+        optional: true
+      oracledb:
+        optional: true
+      pg:
+        optional: true
+      pg-native:
+        optional: true
+      pg-query-stream:
+        optional: true
+      redis:
+        optional: true
+      sql.js:
+        optional: true
+      sqlite3:
+        optional: true
+      ts-node:
+        optional: true
+      typeorm-aurora-data-api-driver:
+        optional: true
 
   typescript-eslint@8.34.0:
     resolution: {integrity: sha512-MRpfN7uYjTrTGigFCt8sRyNqJFhjN0WwZecldaqhWm+wy0gaRt8Edb/3cuUy0zdq2opJWT6iXINKAtewnDOltQ==}
@@ -6052,6 +6173,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@nestjs/config@4.0.2(@nestjs/common@11.1.3(reflect-metadata@0.2.2)(rxjs@7.8.2))(rxjs@7.8.2)':
+    dependencies:
+      '@nestjs/common': 11.1.3(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      dotenv: 16.4.7
+      dotenv-expand: 12.0.1
+      lodash: 4.17.21
+      rxjs: 7.8.2
+
   '@nestjs/core@11.1.3(@nestjs/common@11.1.3(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)':
     dependencies:
       '@nestjs/common': 11.1.3(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -6096,6 +6225,14 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@nestjs/platform-express': 11.1.3(@nestjs/common@11.1.3(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.3)
+
+  '@nestjs/typeorm@11.0.0(@nestjs/common@11.1.3(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typeorm@0.3.27(mysql2@3.15.3)(reflect-metadata@0.2.2)(ts-node@10.9.2(@swc/core@1.12.1)(@types/node@22.15.31)(typescript@5.8.3)))':
+    dependencies:
+      '@nestjs/common': 11.1.3(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core': 11.1.3(@nestjs/common@11.1.3(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      reflect-metadata: 0.2.2
+      rxjs: 7.8.2
+      typeorm: 0.3.27(mysql2@3.15.3)(reflect-metadata@0.2.2)(ts-node@10.9.2(@swc/core@1.12.1)(@types/node@22.15.31)(typescript@5.8.3))
 
   '@next/env@15.3.3': {}
 
@@ -6316,6 +6453,8 @@ snapshots:
   '@sinonjs/fake-timers@10.3.0':
     dependencies:
       '@sinonjs/commons': 3.0.1
+
+  '@sqltools/formatter@1.2.5': {}
 
   '@swc/cli@0.6.0(@swc/core@1.12.1)(chokidar@4.0.3)':
     dependencies:
@@ -6953,6 +7092,8 @@ snapshots:
       normalize-path: 3.0.0
       picomatch: 2.3.1
 
+  app-root-path@3.1.0: {}
+
   append-field@1.0.0: {}
 
   arch@3.0.0: {}
@@ -7204,6 +7345,11 @@ snapshots:
   buffer-from@1.1.2: {}
 
   buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
+  buffer@6.0.3:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
@@ -7478,6 +7624,8 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.27.6
 
+  dayjs@1.11.19: {}
+
   debug@3.2.7:
     dependencies:
       ms: 2.1.3
@@ -7555,6 +7703,14 @@ snapshots:
   doctrine@2.1.0:
     dependencies:
       esutils: 2.0.3
+
+  dotenv-expand@12.0.1:
+    dependencies:
+      dotenv: 16.4.7
+
+  dotenv@16.4.7: {}
+
+  dotenv@16.6.1: {}
 
   dotenv@17.2.3: {}
 
@@ -10200,6 +10356,12 @@ snapshots:
 
   setprototypeof@1.2.0: {}
 
+  sha.js@2.4.12:
+    dependencies:
+      inherits: 2.0.4
+      safe-buffer: 5.2.1
+      to-buffer: 1.2.2
+
   sharp@0.34.2:
     dependencies:
       color: 4.2.3
@@ -10307,6 +10469,8 @@ snapshots:
   spawn-command@0.0.2: {}
 
   sprintf-js@1.0.3: {}
+
+  sql-highlight@6.1.0: {}
 
   sqlstring@2.3.3: {}
 
@@ -10592,6 +10756,12 @@ snapshots:
 
   tmpl@1.0.5: {}
 
+  to-buffer@1.2.2:
+    dependencies:
+      isarray: 2.0.5
+      safe-buffer: 5.2.1
+      typed-array-buffer: 1.0.3
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
@@ -10763,6 +10933,30 @@ snapshots:
       reflect.getprototypeof: 1.0.10
 
   typedarray@0.0.6: {}
+
+  typeorm@0.3.27(mysql2@3.15.3)(reflect-metadata@0.2.2)(ts-node@10.9.2(@swc/core@1.12.1)(@types/node@22.15.31)(typescript@5.8.3)):
+    dependencies:
+      '@sqltools/formatter': 1.2.5
+      ansis: 3.17.0
+      app-root-path: 3.1.0
+      buffer: 6.0.3
+      dayjs: 1.11.19
+      debug: 4.4.1
+      dedent: 1.6.0
+      dotenv: 16.6.1
+      glob: 10.4.5
+      reflect-metadata: 0.2.2
+      sha.js: 2.4.12
+      sql-highlight: 6.1.0
+      tslib: 2.8.1
+      uuid: 11.1.0
+      yargs: 17.7.2
+    optionalDependencies:
+      mysql2: 3.15.3
+      ts-node: 10.9.2(@swc/core@1.12.1)(@types/node@22.15.31)(typescript@5.8.3)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
 
   typescript-eslint@8.34.0(eslint@9.29.0(jiti@1.21.7))(typescript@5.8.3):
     dependencies:


### PR DESCRIPTION
## 📝 Changes

  ### Backend (NestJS)
  - Set up NestJS backend with TypeORM and MySQL connection
  - Create Post entity mapped to RDS posts table
  - Implement Posts module/controller/service
  - Add REST API endpoints:
    - `GET /posts` - Retrieve all posts with displayId
    - `GET /posts/:displayId` - Retrieve single post by displayId

  ### Deployment (AWS EC2)
  - Deploy NestJS backend to EC2  
  - Configure PM2 for auto-restart on system reboot
  - Add EC2 security group to RDS inbound rules

  ### Frontend (Next.js)
  - Refactor API routes to proxy requests to NestJS backend
  - Remove direct MySQL connection from Next.js

  - /post is now accessible on production (Vercel → EC2 → RDS)
    - Check https://www.crohasang.com/post

### Document
- Add Claude.md
 